### PR TITLE
Guard against out-of-bounds panic in mySplitBuf()

### DIFF
--- a/goignore.go
+++ b/goignore.go
@@ -393,7 +393,7 @@ func (g *GitIgnore) matchesPathNoError(path string) bool {
 // Tries to match the path to all the rules in the gitignore
 // Returns an error if the path is longer than 4096 bytes.
 func (g *GitIgnore) MatchesPath(path string) (bool, error) {
-	// Guard against out-of-bounds in mySplitBuf()
+	// Guard against out-of-bounds panic in mySplitBuf()
 	if len(path) > maxPathLength() {
 		return false, errors.New("path cannot be longer than " + strconv.Itoa(maxPathLength()) + " bytes")
 	}

--- a/goignore.go
+++ b/goignore.go
@@ -14,6 +14,8 @@ func bufferLengthForPathComponents() int {
 }
 
 func maxPathLength() int {
+	// You need atleast 1 character between each separator character for mySplitBuf() to use up a path component
+	// e.g. "a/a/a/a/a/..."
 	return 2 * bufferLengthForPathComponents()
 }
 

--- a/goignore_test.go
+++ b/goignore_test.go
@@ -399,12 +399,15 @@ func TestMySplit(t *testing.T) {
 
 func TestMaxPathLengthError(t *testing.T) {
 	g := CompileIgnoreLines([]string{""})
-	longPath := strings.Repeat("a/", bufferLengthForPathComponents()+1) // 2 bytes above the path length limit
-	_, err := g.MatchesPath(longPath[:])
-	assert.NotEqual(t, nil, err)
 
-	_, err = g.MatchesPath(longPath[:2047]) // 1 less character
+	// The path length limit
+	longPath := strings.Repeat("a", maxPathLength())
+	_, err := g.MatchesPath(longPath)
 	assert.Equal(t, nil, err)
+
+	// 1 character above the path length limit
+	_, err = g.MatchesPath(longPath + "a")
+	assert.NotEqual(t, nil, err)
 }
 
 func FuzzStringMatch(f *testing.F) {

--- a/goignore_test.go
+++ b/goignore_test.go
@@ -385,7 +385,7 @@ func TestMySplitBuf(t *testing.T) {
 
 func TestMaxPathLengthError(t *testing.T) {
 	g := CompileIgnoreLines([]string{""})
-	longPath := strings.Repeat("a/", bufferLengthForPathComponents() + 1) // 2 bytes above the path length limit
+	longPath := strings.Repeat("a/", bufferLengthForPathComponents()+1) // 2 bytes above the path length limit
 	_, err := g.MatchesPath(longPath[:])
 	assert.NotEqual(t, nil, err)
 

--- a/goignore_test.go
+++ b/goignore_test.go
@@ -360,11 +360,20 @@ func TestFolders(t *testing.T) {
 	assert.Equal(t, false, ignoreObject.matchesPathNoError("Fizz/Folder"), "should not match Fizz/Folder")
 }
 
-func TestMySplitBuf(t *testing.T) {
+// Test for both mySplit() and mySplitBuf()
+func TestMySplit(t *testing.T) {
 	type TestCase struct {
 		str       string
 		separator byte
 		expected  []string
+	}
+
+	repeatSlice := func(s string, numTimes int) []string {
+		out := make([]string, numTimes)
+		for i := range out {
+			out[i] = s
+		}
+		return out
 	}
 
 	tests := []TestCase{
@@ -372,6 +381,8 @@ func TestMySplitBuf(t *testing.T) {
 		{"dontsplit", ' ', []string{"dontsplit"}},
 		{"", ' ', []string{}},
 		{"aaaaa", 'a', []string{}},
+		// Make sure we don't crash when splitting the max amount of path components in mySplitBuf()
+		{strings.Repeat("a/", bufferLengthForPathComponents()), '/', repeatSlice("a", bufferLengthForPathComponents())},
 	}
 
 	// mySplitBuf expects a buffer slice of sufficient length.
@@ -379,6 +390,9 @@ func TestMySplitBuf(t *testing.T) {
 
 	for _, test := range tests {
 		result := mySplitBuf(test.str, test.separator, buffer)
+		assert.Equal(t, test.expected, result)
+
+		result = mySplit(test.str, test.separator)
 		assert.Equal(t, test.expected, result)
 	}
 }

--- a/goignore_test.go
+++ b/goignore_test.go
@@ -48,9 +48,9 @@ func ExampleCompileIgnoreLines() {
 	fmt.Println(ignoreObject.MatchesPath("test/foo.js"))
 
 	// Output:
-	// true
-	// true
-	// false
+	// true <nil>
+	// true <nil>
+	// false <nil>
 }
 
 func ExampleCompileIgnoreFile() {
@@ -70,9 +70,9 @@ func ExampleCompileIgnoreFile() {
 	fmt.Println(ignoreObject.MatchesPath("go.mod"))
 
 	// Output:
-	// true
-	// true
-	// false
+	// true <nil>
+	// true <nil>
+	// false <nil>
 }
 
 // Validate the correct handling of the negation operator "!"
@@ -86,10 +86,10 @@ func TestCompileIgnoreLines_HandleIncludePattern(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("a"), "a should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("foo/baz"), "foo/baz should match")
-	assert.Equal(t, false, ignoreObject.MatchesPath("foo"), "foo should not match")
-	assert.Equal(t, false, ignoreObject.MatchesPath("/foo/bar"), "/foo/bar should not match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a"), "a should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/baz"), "foo/baz should match")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("foo"), "foo should not match")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("/foo/bar"), "/foo/bar should not match")
 }
 
 // Validate the correct handling of leading / chars
@@ -102,10 +102,10 @@ func TestCompileIgnoreLines_HandleLeadingSlash(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("a/b/c"), "a/b/c should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("a/b/c/d"), "a/b/c/d should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("d/e/f"), "d/e/f should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("g"), "g should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/b/c"), "a/b/c should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/b/c/d"), "a/b/c/d should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("d/e/f"), "d/e/f should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("g"), "g should match")
 }
 
 // Validate the correct handling of files starting with # or !
@@ -119,12 +119,12 @@ func TestCompileIgnoreLines_HandleLeadingSpecialChars(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("#file.txt"), "#file.txt should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("!file.txt"), "!file.txt should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("a/!file.txt"), "a/!file.txt should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("file.txt"), "file.txt should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("a/file.txt"), "a/file.txt should match")
-	assert.Equal(t, false, ignoreObject.MatchesPath("file2.txt"), "file2.txt should not match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("#file.txt"), "#file.txt should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("!file.txt"), "!file.txt should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/!file.txt"), "a/!file.txt should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("file.txt"), "file.txt should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/file.txt"), "a/file.txt should match")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("file2.txt"), "file2.txt should not match")
 
 }
 
@@ -134,9 +134,9 @@ func TestCompileIgnoreLines_HandleAllFilesInDir(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("Documentation/git.html"), "Documentation/git.html should match")
-	assert.Equal(t, false, ignoreObject.MatchesPath("Documentation/ppc/ppc.html"), "Documentation/ppc/ppc.html should not match")
-	assert.Equal(t, false, ignoreObject.MatchesPath("tools/perf/Documentation/perf.html"), "tools/perf/Documentation/perf.html should not match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("Documentation/git.html"), "Documentation/git.html should match")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("Documentation/ppc/ppc.html"), "Documentation/ppc/ppc.html should not match")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("tools/perf/Documentation/perf.html"), "tools/perf/Documentation/perf.html should not match")
 }
 
 // Validate the correct handling of "**"
@@ -145,11 +145,11 @@ func TestCompileIgnoreLines_HandleDoubleStar(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("foo"), "foo should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("baz/foo"), "baz/foo should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("bar"), "bar should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("fizz/bar"), "fizz/bar should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("baz/buzz"), "baz/buzz should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo"), "foo should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("baz/foo"), "baz/foo should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar"), "bar should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("fizz/bar"), "fizz/bar should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("baz/buzz"), "baz/buzz should match")
 }
 
 // Validate the correct handling of leading slash
@@ -158,8 +158,8 @@ func TestCompileIgnoreLines_HandleLeadingSlashPath(t *testing.T) {
 
 	assert.NotNil(t, object, "Returned object should not be nil")
 
-	assert.Equal(t, true, object.MatchesPath("hello.c"), "hello.c should match")
-	assert.Equal(t, false, object.MatchesPath("foo/hello.c"), "foo/hello.c should not match")
+	assert.Equal(t, true, object.matchesPathNoError("hello.c"), "hello.c should match")
+	assert.Equal(t, false, object.matchesPathNoError("foo/hello.c"), "foo/hello.c should not match")
 }
 
 func TestCompileIgnoreLines_CheckNestedDotFiles(t *testing.T) {
@@ -177,9 +177,9 @@ func TestCompileIgnoreLines_CheckNestedDotFiles(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("external/foobar/angular.foo.css"), "external/foobar/angular.foo.css should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("external/barfoo/.gitignore"), "external/barfoo/.gitignore should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("external/barfoo/.bower.json"), "external/barfoo/.bower.json should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("external/foobar/angular.foo.css"), "external/foobar/angular.foo.css should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("external/barfoo/.gitignore"), "external/barfoo/.gitignore should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("external/barfoo/.bower.json"), "external/barfoo/.bower.json should match")
 }
 
 func TestCompileIgnoreLines_CarriageReturn(t *testing.T) {
@@ -188,12 +188,12 @@ func TestCompileIgnoreLines_CarriageReturn(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("abc/def/child"), "abc/def/child should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("a/b/c/d"), "a/b/c/d should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("abc/def/child"), "abc/def/child should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/b/c/d"), "a/b/c/d should match")
 
-	assert.Equal(t, false, ignoreObject.MatchesPath("abc"), "abc should not match")
-	assert.Equal(t, false, ignoreObject.MatchesPath("def"), "def should not match")
-	assert.Equal(t, false, ignoreObject.MatchesPath("bd"), "bd should not match")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("abc"), "abc should not match")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("def"), "def should not match")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("bd"), "bd should not match")
 }
 
 func TestCompileIgnoreLines_WindowsPath(t *testing.T) {
@@ -205,8 +205,8 @@ func TestCompileIgnoreLines_WindowsPath(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("abc\\def\\child"), "abc\\def\\child should match")
-	assert.Equal(t, true, ignoreObject.MatchesPath("a\\b\\c\\d"), "a\\b\\c\\d should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("abc\\def\\child"), "abc\\def\\child should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a\\b\\c\\d"), "a\\b\\c\\d should match")
 }
 
 func TestWildCardFiles(t *testing.T) {
@@ -216,18 +216,18 @@ func TestWildCardFiles(t *testing.T) {
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
 	// Paths which are targeted by the above "lines"
-	assert.Equal(t, true, ignoreObject.MatchesPath("yo.swp"), "should ignore all swp files")
-	assert.Equal(t, true, ignoreObject.MatchesPath("something/else/but/it/hasyo.swp"), "should ignore all swp files in other directories")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("yo.swp"), "should ignore all swp files")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("something/else/but/it/hasyo.swp"), "should ignore all swp files in other directories")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("foo/bar.wat"), "should ignore all wat files in foo - nonpreceding /")
-	assert.Equal(t, false, ignoreObject.MatchesPath("/foo/something.wat"), "should not ignore all wat files in foo - preceding /")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/bar.wat"), "should ignore all wat files in foo - nonpreceding /")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("/foo/something.wat"), "should not ignore all wat files in foo - preceding /")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("bar/something.txt"), "should ignore all txt files in bar - nonpreceding /")
-	assert.Equal(t, false, ignoreObject.MatchesPath("/bar/somethingelse.txt"), "should not ignore all txt files in bar - preceding /")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar/something.txt"), "should ignore all txt files in bar - nonpreceding /")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("/bar/somethingelse.txt"), "should not ignore all txt files in bar - preceding /")
 
 	// Paths which are not targeted by the above "lines"
-	assert.Equal(t, false, ignoreObject.MatchesPath("something/not/infoo/wat.wat"), "wat files should only be ignored in foo")
-	assert.Equal(t, false, ignoreObject.MatchesPath("something/not/infoo/wat.txt"), "txt files should only be ignored in bar")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("something/not/infoo/wat.wat"), "wat files should only be ignored in foo")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("something/not/infoo/wat.txt"), "txt files should only be ignored in bar")
 }
 
 func TestPrecedingSlash(t *testing.T) {
@@ -236,14 +236,14 @@ func TestPrecedingSlash(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("foo/bar.wat"), "should ignore all files in foo - nonpreceding /")
-	assert.Equal(t, false, ignoreObject.MatchesPath("/foo/something.txt"), "should not ignore all files in foo - preceding /")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/bar.wat"), "should ignore all files in foo - nonpreceding /")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("/foo/something.txt"), "should not ignore all files in foo - preceding /")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("bar/something.txt"), "should ignore all files in bar - nonpreceding /")
-	assert.Equal(t, false, ignoreObject.MatchesPath("/bar/somethingelse.go"), "should not ignore all files in bar - preceding /")
-	assert.Equal(t, false, ignoreObject.MatchesPath("/boo/something/bar/boo.txt"), "should not ignore all files if bar is a sub directory")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar/something.txt"), "should ignore all files in bar - nonpreceding /")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("/bar/somethingelse.go"), "should not ignore all files in bar - preceding /")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("/boo/something/bar/boo.txt"), "should not ignore all files if bar is a sub directory")
 
-	assert.Equal(t, false, ignoreObject.MatchesPath("something/foo/something.txt"), "should only ignore top level foo directories - not nested")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("something/foo/something.txt"), "should only ignore top level foo directories - not nested")
 }
 
 func TestDirOnlyMatching(t *testing.T) {
@@ -252,12 +252,12 @@ func TestDirOnlyMatching(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("foo/"), "should match foo directory")
-	assert.Equal(t, true, ignoreObject.MatchesPath("bar/"), "should match bar directory")
-	assert.Equal(t, false, ignoreObject.MatchesPath("foo"), "should not match foo file")
-	assert.Equal(t, false, ignoreObject.MatchesPath("bar"), "should not match bar file")
-	assert.Equal(t, true, ignoreObject.MatchesPath("foo/bar"), "should match nested files in foo")
-	assert.Equal(t, true, ignoreObject.MatchesPath("bar/foo"), "should match nested files in bar")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/"), "should match foo directory")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar/"), "should match bar directory")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("foo"), "should not match foo file")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("bar"), "should not match bar file")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/bar"), "should match nested files in foo")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar/foo"), "should match nested files in bar")
 }
 
 func TestCharacterClasses(t *testing.T) {
@@ -266,43 +266,43 @@ func TestCharacterClasses(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("a-files"), "should match a-files")
-	assert.Equal(t, true, ignoreObject.MatchesPath("g-files"), "should match g-files")
-	assert.Equal(t, true, ignoreObject.MatchesPath("z-files"), "should match z-files")
-	assert.Equal(t, true, ignoreObject.MatchesPath("!-files"), "should match !-files")
-	assert.Equal(t, true, ignoreObject.MatchesPath("*-files"), "should match *-files")
-	assert.Equal(t, false, ignoreObject.MatchesPath("8-files"), "should not match 8-files")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a-files"), "should match a-files")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("g-files"), "should match g-files")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("z-files"), "should match z-files")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("!-files"), "should match !-files")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("*-files"), "should match *-files")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("8-files"), "should not match 8-files")
 
 	gitIgnore = []string{"[!a-zA-Z*!]-files"}
 	ignoreObject = CompileIgnoreLines(gitIgnore)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, false, ignoreObject.MatchesPath("a-files"), "should not match a-files")
-	assert.Equal(t, false, ignoreObject.MatchesPath("g-files"), "should not match g-files")
-	assert.Equal(t, false, ignoreObject.MatchesPath("z-files"), "should not match z-files")
-	assert.Equal(t, false, ignoreObject.MatchesPath("!-files"), "should not match !-files")
-	assert.Equal(t, false, ignoreObject.MatchesPath("*-files"), "should not match *-files")
-	assert.Equal(t, true, ignoreObject.MatchesPath("8-files"), "should match 8-files")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("a-files"), "should not match a-files")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("g-files"), "should not match g-files")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("z-files"), "should not match z-files")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("!-files"), "should not match !-files")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("*-files"), "should not match *-files")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("8-files"), "should match 8-files")
 
 	gitIgnore = []string{"[]-]"}
 	ignoreObject = CompileIgnoreLines(gitIgnore)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("]"), "should match ]")
-	assert.Equal(t, true, ignoreObject.MatchesPath("-"), "should match -")
-	assert.Equal(t, false, ignoreObject.MatchesPath("[]-]"), "should not match []-]")
-	assert.Equal(t, false, ignoreObject.MatchesPath("[]-]"), "should not match -]")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("]"), "should match ]")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("-"), "should match -")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("[]-]"), "should not match []-]")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("[]-]"), "should not match -]")
 
 	gitIgnore = []string{"[[:digit:]].txt", "[:alpha:].txt"}
 	ignoreObject = CompileIgnoreLines(gitIgnore)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.MatchesPath("6.txt"), "should match 6.txt")
-	assert.Equal(t, false, ignoreObject.MatchesPath("z.txt"), "should not match z.txt")
-	assert.Equal(t, true, ignoreObject.MatchesPath("a.txt"), "should match a.txt")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("6.txt"), "should match 6.txt")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("z.txt"), "should not match z.txt")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a.txt"), "should match a.txt")
 }
 
 func TestUnclosedCharacterClass(t *testing.T) {
@@ -310,16 +310,16 @@ func TestUnclosedCharacterClass(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, false, ignoreObject.MatchesPath("["), "should not match [")
-	assert.Equal(t, false, ignoreObject.MatchesPath("*["), "should not match *[")
-	assert.Equal(t, false, ignoreObject.MatchesPath("[*"), "should not match [*")
-	assert.Equal(t, false, ignoreObject.MatchesPath("*[*"), "should not match *[*")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("["), "should not match [")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("*["), "should not match *[")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("[*"), "should not match [*")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("*[*"), "should not match *[*")
 
 	gitIgnore = []string{"[a-z][[]A-Z*-files"}
 	ignoreObject = CompileIgnoreLines(gitIgnore)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, true, ignoreObject.MatchesPath("a[A-Z-files"), "should match a[A-Z-files")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a[A-Z-files"), "should match a[A-Z-files")
 }
 
 func TestStarExponentialBehaviour(t *testing.T) {
@@ -327,7 +327,7 @@ func TestStarExponentialBehaviour(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, false, ignoreObject.MatchesPath("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"), "should not match")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"), "should not match")
 }
 
 func TestStarStarExponentialBehaviour(t *testing.T) {
@@ -335,7 +335,7 @@ func TestStarStarExponentialBehaviour(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, true, ignoreObject.MatchesPath("a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/b"), "should match")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/b"), "should match")
 }
 
 func TestEscaping(t *testing.T) {
@@ -343,10 +343,10 @@ func TestEscaping(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, true, ignoreObject.MatchesPath("[hello"), "should match [hello")
-	assert.Equal(t, false, ignoreObject.MatchesPath("bye[]"), "should not match bye[]")
-	assert.Equal(t, false, ignoreObject.MatchesPath("bye["), "should not match bye[")
-	assert.Equal(t, false, ignoreObject.MatchesPath("bye[\\]"), "should not match bye[\\]")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("[hello"), "should match [hello")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("bye[]"), "should not match bye[]")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("bye["), "should not match bye[")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("bye[\\]"), "should not match bye[\\]")
 }
 
 func TestFolders(t *testing.T) {
@@ -354,10 +354,43 @@ func TestFolders(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, true, ignoreObject.MatchesPath("Folder/Folder"), "should match Folder/Folder")
-	assert.Equal(t, true, ignoreObject.MatchesPath("Folder/Buzz"), "should match Folder/Buzz")
-	assert.Equal(t, true, ignoreObject.MatchesPath("Bar/Folder/"), "should match Bar/Folder/")
-	assert.Equal(t, false, ignoreObject.MatchesPath("Fizz/Folder"), "should not match Fizz/Folder")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("Folder/Folder"), "should match Folder/Folder")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("Folder/Buzz"), "should match Folder/Buzz")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("Bar/Folder/"), "should match Bar/Folder/")
+	assert.Equal(t, false, ignoreObject.matchesPathNoError("Fizz/Folder"), "should not match Fizz/Folder")
+}
+
+func TestMySplitBuf(t *testing.T) {
+	type TestCase struct {
+		str       string
+		separator byte
+		expected  []string
+	}
+
+	tests := []TestCase{
+		{"this is a test", ' ', []string{"this", "is", "a", "test"}},
+		{"dontsplit", ' ', []string{"dontsplit"}},
+		{"", ' ', []string{}},
+		{"aaaaa", 'a', []string{}},
+	}
+
+	// mySplitBuf expects a buffer slice of sufficient length.
+	buffer := make([]string, bufferLengthForPathComponents())
+
+	for _, test := range tests {
+		result := mySplitBuf(test.str, test.separator, buffer)
+		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestMaxPathLengthError(t *testing.T) {
+	g := CompileIgnoreLines([]string{""})
+	longPath := strings.Repeat("a/", bufferLengthForPathComponents() + 1) // 2 bytes above the path length limit
+	_, err := g.MatchesPath(longPath[:])
+	assert.NotEqual(t, nil, err)
+
+	_, err = g.MatchesPath(longPath[:2047]) // 1 less character
+	assert.Equal(t, nil, err)
 }
 
 func FuzzStringMatch(f *testing.F) {


### PR DESCRIPTION
Makes `MatchesPath()` return an error instead of panicking when the split path components buffer would be exceeded
Adds a test for this new error return, as well as a new test for `mySplit()` and `mySplitBuf()`.

I haven't changed the 4096 path length limit