### PR TITLE
Fix bug where single asterix paths would never be ignored

### DIFF
--- a/goignore.go
+++ b/goignore.go
@@ -406,9 +406,6 @@ func (g *GitIgnore) MatchesPath(path string) (bool, error) {
 		path = "/"
 		isDir = true
 	}
-	if path == "*" {
-		return false, nil
-	}
 	if !fs.ValidPath(path) {
 		return false, nil
 	}

--- a/goignore_test.go
+++ b/goignore_test.go
@@ -338,6 +338,14 @@ func TestStarStarExponentialBehaviour(t *testing.T) {
 	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/b"), "should match")
 }
 
+func TestStarFilepath(t *testing.T) {
+	gitIgnore := []string{"\\*"}
+	ignoreObject := CompileIgnoreLines(gitIgnore)
+
+	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
+	assert.Equal(t, true, ignoreObject.matchesPathNoError("*"), "should match")
+}
+
 func TestEscaping(t *testing.T) {
 	gitIgnore := []string{"\\[hello", "bye[\\]"}
 	ignoreObject := CompileIgnoreLines(gitIgnore)


### PR DESCRIPTION
A filename `*` can be ignored by .gitignore with something like:
-  `*` (ignores everything including `*`)
- `\*` (only ignores `*`)

`*` is a legal filename on Linux, but isn't on Windows.