### PR TITLE
Use mySplit() instead of mySplitBuf() to make MatchesPath() thread-safe

### DIFF
--- a/goignore.go
+++ b/goignore.go
@@ -409,7 +409,7 @@ func (g *GitIgnore) MatchesPath(path string) (bool, error) {
 	if !fs.ValidPath(path) {
 		return false, nil
 	}
-	pathComponents := mySplitBuf(path, '/', g.pathComponentsBuf)
+	pathComponents := mySplit(path, '/')
 	matched := false
 
 	for _, rule := range g.Rules {


### PR DESCRIPTION
`MatchesPath()` has a data race when calling it on the same GitIgnore object from multiple threads because they all modify the common `pathComponentsBuf`

I replaced the `mySplitBuf()` call with `mySplit()`
It seems to be like 2% slower at worst when I tried benchmarking it. (Noise?)

I feel like we can remove all the `mySplitBuf()` code, associated tests and the `path cannot be longer than ... bytes` error return. Then we would be back to having a (nearly) identical interface to [go-gitignore](https://github.com/sabhiram/go-gitignore) and less code to worry about.

Do you know a better solution?