### PR TITLE
Remove MatchesPath() error return

### DIFF
--- a/goignore.go
+++ b/goignore.go
@@ -449,14 +449,8 @@ func createRule(pattern string) rule {
 	}
 }
 
-func (g *GitIgnore) matchesPathNoError(path string) bool {
-	result, _ := g.MatchesPath(path)
-	return result
-}
-
 // Tries to match the path to all the rules in the gitignore
-// Returns an error if the path is longer than 4096 bytes.
-func (g *GitIgnore) MatchesPath(path string) (bool, error) {
+func (g *GitIgnore) MatchesPath(path string) bool {
 	// TODO: check if path actually points to a directory on the filesystem
 	isDir := strings.HasSuffix(path, "/")
 	path = filepath.Clean(path)
@@ -466,7 +460,7 @@ func (g *GitIgnore) MatchesPath(path string) (bool, error) {
 		isDir = true
 	}
 	if !fs.ValidPath(path) {
-		return false, nil
+		return false
 	}
 	pathComponents := mySplit(path, '/')
 	matched := false
@@ -480,5 +474,5 @@ func (g *GitIgnore) MatchesPath(path string) (bool, error) {
 			}
 		}
 	}
-	return matched, nil
+	return matched
 }

--- a/goignore_test.go
+++ b/goignore_test.go
@@ -40,7 +40,7 @@ func ExampleCompileIgnoreLines() {
 	ignoreObject := CompileIgnoreLines("node_modules", "*.out", "foo/*.c")
 
 	// You can test the ignoreObject against various paths using the
-	// "Match()" interface method. This pretty much is up to
+	// "MatchesPath()" interface method. This pretty much is up to
 	// the users interpretation. In the case of a ".gitignore" file,
 	// a "match" would indicate that a given path would be ignored.
 	fmt.Println(ignoreObject.MatchesPath("node_modules/test/foo.js"))
@@ -63,7 +63,7 @@ func ExampleCompileIgnoreFile() {
 	}
 
 	// You can test the ignoreObject against various paths using the
-	// "Match()" interface method.
+	// "MatchesPath()" interface method.
 	// int this example, we test paths against the .gitignore file of this package.
 	fmt.Println(ignoreObject.MatchesPath("bin/goignore.so"))
 	fmt.Println(ignoreObject.MatchesPath("goignore.test"))

--- a/goignore_test.go
+++ b/goignore_test.go
@@ -48,9 +48,9 @@ func ExampleCompileIgnoreLines() {
 	fmt.Println(ignoreObject.MatchesPath("test/foo.js"))
 
 	// Output:
-	// true <nil>
-	// true <nil>
-	// false <nil>
+	// true
+	// true
+	// false
 }
 
 func ExampleCompileIgnoreFile() {
@@ -70,9 +70,9 @@ func ExampleCompileIgnoreFile() {
 	fmt.Println(ignoreObject.MatchesPath("go.mod"))
 
 	// Output:
-	// true <nil>
-	// true <nil>
-	// false <nil>
+	// true
+	// true
+	// false
 }
 
 // Validate the correct handling of the negation operator "!"
@@ -86,10 +86,10 @@ func TestCompileIgnoreLines_HandleIncludePattern(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a"), "a should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/baz"), "foo/baz should match")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("foo"), "foo should not match")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("/foo/bar"), "/foo/bar should not match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a"), "a should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("foo/baz"), "foo/baz should match")
+	assert.Equal(t, false, ignoreObject.MatchesPath("foo"), "foo should not match")
+	assert.Equal(t, false, ignoreObject.MatchesPath("/foo/bar"), "/foo/bar should not match")
 }
 
 // Validate the correct handling of leading / chars
@@ -102,10 +102,10 @@ func TestCompileIgnoreLines_HandleLeadingSlash(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/b/c"), "a/b/c should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/b/c/d"), "a/b/c/d should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("d/e/f"), "d/e/f should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("g"), "g should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a/b/c"), "a/b/c should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a/b/c/d"), "a/b/c/d should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("d/e/f"), "d/e/f should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("g"), "g should match")
 }
 
 // Validate the correct handling of files starting with # or !
@@ -119,12 +119,12 @@ func TestCompileIgnoreLines_HandleLeadingSpecialChars(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("#file.txt"), "#file.txt should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("!file.txt"), "!file.txt should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/!file.txt"), "a/!file.txt should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("file.txt"), "file.txt should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/file.txt"), "a/file.txt should match")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("file2.txt"), "file2.txt should not match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("#file.txt"), "#file.txt should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("!file.txt"), "!file.txt should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a/!file.txt"), "a/!file.txt should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("file.txt"), "file.txt should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a/file.txt"), "a/file.txt should match")
+	assert.Equal(t, false, ignoreObject.MatchesPath("file2.txt"), "file2.txt should not match")
 
 }
 
@@ -134,9 +134,9 @@ func TestCompileIgnoreLines_HandleAllFilesInDir(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("Documentation/git.html"), "Documentation/git.html should match")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("Documentation/ppc/ppc.html"), "Documentation/ppc/ppc.html should not match")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("tools/perf/Documentation/perf.html"), "tools/perf/Documentation/perf.html should not match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("Documentation/git.html"), "Documentation/git.html should match")
+	assert.Equal(t, false, ignoreObject.MatchesPath("Documentation/ppc/ppc.html"), "Documentation/ppc/ppc.html should not match")
+	assert.Equal(t, false, ignoreObject.MatchesPath("tools/perf/Documentation/perf.html"), "tools/perf/Documentation/perf.html should not match")
 }
 
 // Validate the correct handling of "**"
@@ -145,11 +145,11 @@ func TestCompileIgnoreLines_HandleDoubleStar(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo"), "foo should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("baz/foo"), "baz/foo should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar"), "bar should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("fizz/bar"), "fizz/bar should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("baz/buzz"), "baz/buzz should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("foo"), "foo should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("baz/foo"), "baz/foo should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("bar"), "bar should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("fizz/bar"), "fizz/bar should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("baz/buzz"), "baz/buzz should match")
 }
 
 // Validate the correct handling of leading slash
@@ -158,8 +158,8 @@ func TestCompileIgnoreLines_HandleLeadingSlashPath(t *testing.T) {
 
 	assert.NotNil(t, object, "Returned object should not be nil")
 
-	assert.Equal(t, true, object.matchesPathNoError("hello.c"), "hello.c should match")
-	assert.Equal(t, false, object.matchesPathNoError("foo/hello.c"), "foo/hello.c should not match")
+	assert.Equal(t, true, object.MatchesPath("hello.c"), "hello.c should match")
+	assert.Equal(t, false, object.MatchesPath("foo/hello.c"), "foo/hello.c should not match")
 }
 
 func TestCompileIgnoreLines_CheckNestedDotFiles(t *testing.T) {
@@ -177,9 +177,9 @@ func TestCompileIgnoreLines_CheckNestedDotFiles(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("external/foobar/angular.foo.css"), "external/foobar/angular.foo.css should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("external/barfoo/.gitignore"), "external/barfoo/.gitignore should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("external/barfoo/.bower.json"), "external/barfoo/.bower.json should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("external/foobar/angular.foo.css"), "external/foobar/angular.foo.css should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("external/barfoo/.gitignore"), "external/barfoo/.gitignore should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("external/barfoo/.bower.json"), "external/barfoo/.bower.json should match")
 }
 
 func TestCompileIgnoreLines_CarriageReturn(t *testing.T) {
@@ -188,12 +188,12 @@ func TestCompileIgnoreLines_CarriageReturn(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("abc/def/child"), "abc/def/child should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/b/c/d"), "a/b/c/d should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("abc/def/child"), "abc/def/child should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a/b/c/d"), "a/b/c/d should match")
 
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("abc"), "abc should not match")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("def"), "def should not match")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("bd"), "bd should not match")
+	assert.Equal(t, false, ignoreObject.MatchesPath("abc"), "abc should not match")
+	assert.Equal(t, false, ignoreObject.MatchesPath("def"), "def should not match")
+	assert.Equal(t, false, ignoreObject.MatchesPath("bd"), "bd should not match")
 }
 
 func TestCompileIgnoreLines_WindowsPath(t *testing.T) {
@@ -205,8 +205,8 @@ func TestCompileIgnoreLines_WindowsPath(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("abc\\def\\child"), "abc\\def\\child should match")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a\\b\\c\\d"), "a\\b\\c\\d should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("abc\\def\\child"), "abc\\def\\child should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a\\b\\c\\d"), "a\\b\\c\\d should match")
 }
 
 func TestWildCardFiles(t *testing.T) {
@@ -216,18 +216,18 @@ func TestWildCardFiles(t *testing.T) {
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
 	// Paths which are targeted by the above "lines"
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("yo.swp"), "should ignore all swp files")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("something/else/but/it/hasyo.swp"), "should ignore all swp files in other directories")
+	assert.Equal(t, true, ignoreObject.MatchesPath("yo.swp"), "should ignore all swp files")
+	assert.Equal(t, true, ignoreObject.MatchesPath("something/else/but/it/hasyo.swp"), "should ignore all swp files in other directories")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/bar.wat"), "should ignore all wat files in foo - nonpreceding /")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("/foo/something.wat"), "should not ignore all wat files in foo - preceding /")
+	assert.Equal(t, true, ignoreObject.MatchesPath("foo/bar.wat"), "should ignore all wat files in foo - nonpreceding /")
+	assert.Equal(t, false, ignoreObject.MatchesPath("/foo/something.wat"), "should not ignore all wat files in foo - preceding /")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar/something.txt"), "should ignore all txt files in bar - nonpreceding /")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("/bar/somethingelse.txt"), "should not ignore all txt files in bar - preceding /")
+	assert.Equal(t, true, ignoreObject.MatchesPath("bar/something.txt"), "should ignore all txt files in bar - nonpreceding /")
+	assert.Equal(t, false, ignoreObject.MatchesPath("/bar/somethingelse.txt"), "should not ignore all txt files in bar - preceding /")
 
 	// Paths which are not targeted by the above "lines"
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("something/not/infoo/wat.wat"), "wat files should only be ignored in foo")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("something/not/infoo/wat.txt"), "txt files should only be ignored in bar")
+	assert.Equal(t, false, ignoreObject.MatchesPath("something/not/infoo/wat.wat"), "wat files should only be ignored in foo")
+	assert.Equal(t, false, ignoreObject.MatchesPath("something/not/infoo/wat.txt"), "txt files should only be ignored in bar")
 }
 
 func TestPrecedingSlash(t *testing.T) {
@@ -236,14 +236,14 @@ func TestPrecedingSlash(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/bar.wat"), "should ignore all files in foo - nonpreceding /")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("/foo/something.txt"), "should not ignore all files in foo - preceding /")
+	assert.Equal(t, true, ignoreObject.MatchesPath("foo/bar.wat"), "should ignore all files in foo - nonpreceding /")
+	assert.Equal(t, false, ignoreObject.MatchesPath("/foo/something.txt"), "should not ignore all files in foo - preceding /")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar/something.txt"), "should ignore all files in bar - nonpreceding /")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("/bar/somethingelse.go"), "should not ignore all files in bar - preceding /")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("/boo/something/bar/boo.txt"), "should not ignore all files if bar is a sub directory")
+	assert.Equal(t, true, ignoreObject.MatchesPath("bar/something.txt"), "should ignore all files in bar - nonpreceding /")
+	assert.Equal(t, false, ignoreObject.MatchesPath("/bar/somethingelse.go"), "should not ignore all files in bar - preceding /")
+	assert.Equal(t, false, ignoreObject.MatchesPath("/boo/something/bar/boo.txt"), "should not ignore all files if bar is a sub directory")
 
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("something/foo/something.txt"), "should only ignore top level foo directories - not nested")
+	assert.Equal(t, false, ignoreObject.MatchesPath("something/foo/something.txt"), "should only ignore top level foo directories - not nested")
 }
 
 func TestDirOnlyMatching(t *testing.T) {
@@ -252,12 +252,12 @@ func TestDirOnlyMatching(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/"), "should match foo directory")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar/"), "should match bar directory")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("foo"), "should not match foo file")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("bar"), "should not match bar file")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("foo/bar"), "should match nested files in foo")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("bar/foo"), "should match nested files in bar")
+	assert.Equal(t, true, ignoreObject.MatchesPath("foo/"), "should match foo directory")
+	assert.Equal(t, true, ignoreObject.MatchesPath("bar/"), "should match bar directory")
+	assert.Equal(t, false, ignoreObject.MatchesPath("foo"), "should not match foo file")
+	assert.Equal(t, false, ignoreObject.MatchesPath("bar"), "should not match bar file")
+	assert.Equal(t, true, ignoreObject.MatchesPath("foo/bar"), "should match nested files in foo")
+	assert.Equal(t, true, ignoreObject.MatchesPath("bar/foo"), "should match nested files in bar")
 }
 
 func TestCharacterClasses(t *testing.T) {
@@ -266,43 +266,43 @@ func TestCharacterClasses(t *testing.T) {
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a-files"), "should match a-files")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("g-files"), "should match g-files")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("z-files"), "should match z-files")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("!-files"), "should match !-files")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("*-files"), "should match *-files")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("8-files"), "should not match 8-files")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a-files"), "should match a-files")
+	assert.Equal(t, true, ignoreObject.MatchesPath("g-files"), "should match g-files")
+	assert.Equal(t, true, ignoreObject.MatchesPath("z-files"), "should match z-files")
+	assert.Equal(t, true, ignoreObject.MatchesPath("!-files"), "should match !-files")
+	assert.Equal(t, true, ignoreObject.MatchesPath("*-files"), "should match *-files")
+	assert.Equal(t, false, ignoreObject.MatchesPath("8-files"), "should not match 8-files")
 
 	gitIgnore = []string{"[!a-zA-Z*!]-files"}
 	ignoreObject = CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("a-files"), "should not match a-files")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("g-files"), "should not match g-files")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("z-files"), "should not match z-files")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("!-files"), "should not match !-files")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("*-files"), "should not match *-files")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("8-files"), "should match 8-files")
+	assert.Equal(t, false, ignoreObject.MatchesPath("a-files"), "should not match a-files")
+	assert.Equal(t, false, ignoreObject.MatchesPath("g-files"), "should not match g-files")
+	assert.Equal(t, false, ignoreObject.MatchesPath("z-files"), "should not match z-files")
+	assert.Equal(t, false, ignoreObject.MatchesPath("!-files"), "should not match !-files")
+	assert.Equal(t, false, ignoreObject.MatchesPath("*-files"), "should not match *-files")
+	assert.Equal(t, true, ignoreObject.MatchesPath("8-files"), "should match 8-files")
 
 	gitIgnore = []string{"[]-]"}
 	ignoreObject = CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("]"), "should match ]")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("-"), "should match -")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("[]-]"), "should not match []-]")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("[]-]"), "should not match -]")
+	assert.Equal(t, true, ignoreObject.MatchesPath("]"), "should match ]")
+	assert.Equal(t, true, ignoreObject.MatchesPath("-"), "should match -")
+	assert.Equal(t, false, ignoreObject.MatchesPath("[]-]"), "should not match []-]")
+	assert.Equal(t, false, ignoreObject.MatchesPath("[]-]"), "should not match -]")
 
 	gitIgnore = []string{"[[:digit:]].txt", "[:alpha:].txt"}
 	ignoreObject = CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
 
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("6.txt"), "should match 6.txt")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("z.txt"), "should not match z.txt")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a.txt"), "should match a.txt")
+	assert.Equal(t, true, ignoreObject.MatchesPath("6.txt"), "should match 6.txt")
+	assert.Equal(t, false, ignoreObject.MatchesPath("z.txt"), "should not match z.txt")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a.txt"), "should match a.txt")
 }
 
 func TestUnclosedCharacterClass(t *testing.T) {
@@ -310,16 +310,16 @@ func TestUnclosedCharacterClass(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("["), "should not match [")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("*["), "should not match *[")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("[*"), "should not match [*")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("*[*"), "should not match *[*")
+	assert.Equal(t, false, ignoreObject.MatchesPath("["), "should not match [")
+	assert.Equal(t, false, ignoreObject.MatchesPath("*["), "should not match *[")
+	assert.Equal(t, false, ignoreObject.MatchesPath("[*"), "should not match [*")
+	assert.Equal(t, false, ignoreObject.MatchesPath("*[*"), "should not match *[*")
 
 	gitIgnore = []string{"[a-z][[]A-Z*-files"}
 	ignoreObject = CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a[A-Z-files"), "should match a[A-Z-files")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a[A-Z-files"), "should match a[A-Z-files")
 }
 
 func TestStarExponentialBehaviour(t *testing.T) {
@@ -327,7 +327,7 @@ func TestStarExponentialBehaviour(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"), "should not match")
+	assert.Equal(t, false, ignoreObject.MatchesPath("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"), "should not match")
 }
 
 func TestStarStarExponentialBehaviour(t *testing.T) {
@@ -335,7 +335,7 @@ func TestStarStarExponentialBehaviour(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/b"), "should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/b"), "should match")
 }
 
 func TestStarFilepath(t *testing.T) {
@@ -343,7 +343,7 @@ func TestStarFilepath(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("*"), "should match")
+	assert.Equal(t, true, ignoreObject.MatchesPath("*"), "should match")
 }
 
 func TestEscaping(t *testing.T) {
@@ -351,10 +351,10 @@ func TestEscaping(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("[hello"), "should match [hello")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("bye[]"), "should not match bye[]")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("bye["), "should not match bye[")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("bye[\\]"), "should not match bye[\\]")
+	assert.Equal(t, true, ignoreObject.MatchesPath("[hello"), "should match [hello")
+	assert.Equal(t, false, ignoreObject.MatchesPath("bye[]"), "should not match bye[]")
+	assert.Equal(t, false, ignoreObject.MatchesPath("bye["), "should not match bye[")
+	assert.Equal(t, false, ignoreObject.MatchesPath("bye[\\]"), "should not match bye[\\]")
 }
 
 func TestFolders(t *testing.T) {
@@ -362,10 +362,10 @@ func TestFolders(t *testing.T) {
 	ignoreObject := CompileIgnoreLines(gitIgnore...)
 
 	assert.NotNil(t, ignoreObject, "Returned object should not be nil")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("Folder/Folder"), "should match Folder/Folder")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("Folder/Buzz"), "should match Folder/Buzz")
-	assert.Equal(t, true, ignoreObject.matchesPathNoError("Bar/Folder/"), "should match Bar/Folder/")
-	assert.Equal(t, false, ignoreObject.matchesPathNoError("Fizz/Folder"), "should not match Fizz/Folder")
+	assert.Equal(t, true, ignoreObject.MatchesPath("Folder/Folder"), "should match Folder/Folder")
+	assert.Equal(t, true, ignoreObject.MatchesPath("Folder/Buzz"), "should match Folder/Buzz")
+	assert.Equal(t, true, ignoreObject.MatchesPath("Bar/Folder/"), "should match Bar/Folder/")
+	assert.Equal(t, false, ignoreObject.MatchesPath("Fizz/Folder"), "should not match Fizz/Folder")
 }
 
 // Test for both mySplit() and mySplitBuf()

--- a/readme.md
+++ b/readme.md
@@ -19,17 +19,15 @@ package main
 import "github.com/botondmester/goignore"
 
 func main() {
-    ignore := goignore.CompileIgnoreLines([]string{
+    ignore := goignore.CompileIgnoreLines(
         "/*",
         "!/foo",
         "/foo/*",
         "!/foo/bar",
-    })
+    )
 
     // should print `foo/baz is ignored`
-    isIgnored, _ := ignore.MatchesPath("foo/baz")
-
-    if isIgnored {
+    if ignore.MatchesPath("foo/baz") {
         println("foo/baz is ignored")
     } else {
         println("foo/baz is not ignored")


### PR DESCRIPTION
This makes it the same function signature as [go-gitignore](https://github.com/sabhiram/go-gitignore) and let's me remove the ugly `matchesPathNoError()`.

Also removed the `// Returns an error if the path is longer than 4096 bytes.` comment which isn't relevant anymore