### PR TITLE
Fix matching speed

### DIFF
--- a/goignore.go
+++ b/goignore.go
@@ -526,27 +526,35 @@ func (g *GitIgnore) MatchesPath(path string) bool {
 	}
 	pathComponents := mySplit(path, '/')
 
-	// First, if there are any parent directories (more than 1 path component), check if they match.
-	for j := 0; j < len(pathComponents)-1; j++ {
-		for i := len(g.rules) - 1; i >= 0; i-- {
-			rule := g.rules[i]
-			if rule.matchesPath(true /* Makes no difference? */, pathComponents[:j+1]) {
-				if rule.Negate {
-					break // Undecided.
-				} else {
-					return true
-				}
-			}
-		}
-	}
-
-	// If no parent directories match, we must check if the whole path matches.
+	// Standard matching - check all rules against the full path
 	for i := len(g.rules) - 1; i >= 0; i-- {
 		rule := g.rules[i]
 
 		if rule.matchesPath(isDir, pathComponents) {
 			if rule.Negate {
-				return false
+				// Only now check if any parent directory is excluded
+				// This is lazy evaluation - we only do expensive parent check when needed
+				parentExcluded := false
+				for j := 0; j < len(pathComponents)-1; j++ {
+					for k := len(g.rules) - 1; k >= 0; k-- {
+						parentRule := g.rules[k]
+						if parentRule.matchesPath(true, pathComponents[:j+1]) {
+							if !parentRule.Negate {
+								parentExcluded = true
+							}
+							break
+						}
+					}
+					if parentExcluded {
+						break
+					}
+				}
+				
+				// If parent is excluded, we cannot re-include this path
+				if !parentExcluded {
+					return false
+				}
+				// If parent is excluded, continue to next rule
 			} else {
 				return true
 			}

--- a/goignore.go
+++ b/goignore.go
@@ -526,7 +526,6 @@ func (g *GitIgnore) MatchesPath(path string) bool {
 	}
 	pathComponents := mySplit(path, '/')
 
-	// Standard matching - check all rules against the full path
 	for i := len(g.rules) - 1; i >= 0; i-- {
 		rule := g.rules[i]
 

--- a/goignore.go
+++ b/goignore.go
@@ -535,6 +535,8 @@ func (g *GitIgnore) MatchesPath(path string) bool {
 				// Only now check if any parent directory is excluded
 				// This is lazy evaluation - we only do expensive parent check when needed
 				parentExcluded := false
+
+			OuterLoop:
 				for j := 0; j < len(pathComponents)-1; j++ {
 					for k := len(g.rules) - 1; k >= 0; k-- {
 						parentRule := g.rules[k]
@@ -542,19 +544,15 @@ func (g *GitIgnore) MatchesPath(path string) bool {
 							if !parentRule.Negate {
 								parentExcluded = true
 							}
-							break
+							break OuterLoop
 						}
 					}
-					if parentExcluded {
-						break
-					}
 				}
-				
+
 				// If parent is excluded, we cannot re-include this path
 				if !parentExcluded {
 					return false
 				}
-				// If parent is excluded, continue to next rule
 			} else {
 				return true
 			}


### PR DESCRIPTION
This fixes the performance regression introduced by https://github.com/botondmester/goignore/pull/14/
Matching speed is now ~3.7x faster, tested on the chromium repository

<img width="681" height="458" alt="image" src="https://github.com/user-attachments/assets/9fc3cf3b-36df-43a6-8234-b1c2892c6dd0" />
